### PR TITLE
Fix for reliable WebSocket send() 

### DIFF
--- a/Sources/gg.datagram.web-requests.sdPlugin/app.js
+++ b/Sources/gg.datagram.web-requests.sdPlugin/app.js
@@ -97,14 +97,20 @@ function sendWebSocket(data) {
     ws.onclose = function(evt) { onClose(this, evt); };
     ws.onopen = function() {
         onOpen(this);
+	    const start = new Date();
         ws.send(body);
-        showOk(data.context);
 		const readyCloseInterval = setInterval(function() {
 			if (ws.bufferedAmount == 0) {
-			  ws.close();
-			  clearInterval(readyCloseInterval);
+			    ws.close();
+			    showOk(data.context);
+			    clearInterval(readyCloseInterval);
 			}
-		}, 100);        
+			else if ((new Date().getTime() - start.getTime()) > 3000) {
+			    showAlert(data.context);
+			    logErr(new Error('WebSocket send timeout'));
+			    clearInterval(readyCloseInterval);
+			}
+		}, 50);        
     };
 }
 

--- a/Sources/gg.datagram.web-requests.sdPlugin/app.js
+++ b/Sources/gg.datagram.web-requests.sdPlugin/app.js
@@ -106,6 +106,7 @@ function sendWebSocket(data) {
                 clearInterval(readyCloseInterval);
             }
             else if ((performance.now() - start) > 3000) {
+                ws.close();
                 showAlert(data.context);
                 logErr(new Error('WebSocket send timeout'));
                 clearInterval(readyCloseInterval);

--- a/Sources/gg.datagram.web-requests.sdPlugin/app.js
+++ b/Sources/gg.datagram.web-requests.sdPlugin/app.js
@@ -97,20 +97,20 @@ function sendWebSocket(data) {
     ws.onclose = function(evt) { onClose(this, evt); };
     ws.onopen = function() {
         onOpen(this);
-	    const start = new Date();
+        const start = new Date();
         ws.send(body);
-		const readyCloseInterval = setInterval(function() {
-			if (ws.bufferedAmount == 0) {
-			    ws.close();
-			    showOk(data.context);
-			    clearInterval(readyCloseInterval);
-			}
-			else if ((new Date().getTime() - start.getTime()) > 3000) {
-			    showAlert(data.context);
-			    logErr(new Error('WebSocket send timeout'));
-			    clearInterval(readyCloseInterval);
-			}
-		}, 50);        
+        const readyCloseInterval = setInterval(function() {
+            if (ws.bufferedAmount == 0) {
+                ws.close();
+                showOk(data.context);
+                clearInterval(readyCloseInterval);
+            }
+            else if ((new Date().getTime() - start.getTime()) > 3000) {
+                showAlert(data.context);
+                logErr(new Error('WebSocket send timeout'));
+                clearInterval(readyCloseInterval);
+            }
+        }, 50);
     };
 }
 

--- a/Sources/gg.datagram.web-requests.sdPlugin/app.js
+++ b/Sources/gg.datagram.web-requests.sdPlugin/app.js
@@ -98,8 +98,13 @@ function sendWebSocket(data) {
     ws.onopen = function() {
         onOpen(this);
         ws.send(body);
-        ws.close();
         showOk(data.context);
+		const readyCloseInterval = setInterval(function() {
+			if (ws.bufferedAmount == 0) {
+			  ws.close();
+			  clearInterval(readyCloseInterval);
+			}
+		}, 100);        
     };
 }
 

--- a/Sources/gg.datagram.web-requests.sdPlugin/app.js
+++ b/Sources/gg.datagram.web-requests.sdPlugin/app.js
@@ -97,7 +97,7 @@ function sendWebSocket(data) {
     ws.onclose = function(evt) { onClose(this, evt); };
     ws.onopen = function() {
         onOpen(this);
-        const start = new Date();
+        const start = performance.now();
         ws.send(body);
         const readyCloseInterval = setInterval(function() {
             if (ws.bufferedAmount == 0) {
@@ -105,7 +105,7 @@ function sendWebSocket(data) {
                 showOk(data.context);
                 clearInterval(readyCloseInterval);
             }
-            else if ((new Date().getTime() - start.getTime()) > 3000) {
+            else if ((performance.now() - start) > 3000) {
                 showAlert(data.context);
                 logErr(new Error('WebSocket send timeout'));
                 clearInterval(readyCloseInterval);


### PR DESCRIPTION
Hey @data-enabler, thanks for this Stream Deck plugin! Very handy 👌 

I noticed that the WebSocket command was sometimes unreliable. I dug deeper and found that whilst the plugin did always connect and disconnect from the WebSocket endpoint, there were instances where the actual data did not get sent through before the disconnect. This is especially noticeable if spamming that particular Stream Deck button.

This PR bug fix resolves this issue by ensureing that send() happens before the close()

Since both [send()](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/send) and [close()](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/close) are async, there is a race condition that the send() can fail silently if the close() happened to complete first.

The 100ms interval was just some value that seemed right to me - feel free to adjust.

Cheers!
Jeremy